### PR TITLE
  generate rubocop_todo

### DIFF
--- a/lib/bankai/generators/lint_generator.rb
+++ b/lib/bankai/generators/lint_generator.rb
@@ -21,6 +21,10 @@ module Bankai
       def rubocop_autocorrect
         Bundler.with_clean_env { run 'bundle exec rubocop --auto-correct' }
       end
+
+      def rubocop_todo
+        Bundler.with_clean_env { run 'bundle exec rubocop --auto-gen-config' }
+      end
     end
   end
 end


### PR DESCRIPTION
因為 rails 會讓 rubocop 自爆（主要是註解）導致 bankai 的出廠值無法馬上使用
所以在 lint generator 裡增加自動產生 rubocop todo 的功能