### PR TITLE
Use full name of DATABASE variables for rails 7.2

### DIFF
--- a/lib/bankai/generator.rb
+++ b/lib/bankai/generator.rb
@@ -10,7 +10,7 @@ module Bankai
 
     class_option :database, type: :string, aliases: '-d', default: 'postgresql',
                             desc: 'Configure for selected database ' \
-                                  "(options: #{DATABASES.join('/')})"
+                                  "(options: #{Rails::Generators::Database::DATABASES.join('/')})"
 
     class_option :capistrano, type: :boolean, default: false,
                               desc: 'Use Capistrano'


### PR DESCRIPTION
## Problem in Rails 7.2
- 在 7.2 之前，`Rails::Generators::Database` module 在 `Rails::Generators::AppBase` 被 include，所以 `lib/bankai/generator.rb:13` 的 `DATABASES` 可以取得 value。
- 在 7.2 之後，`Rails::Generators::AppBase` 就沒有 include `Rails::Generators::Database module`，導致發生錯誤：
  ```
   /vendor/bundle/ruby/3.3.0/gems/bankai-0.13.1/lib/bankai/generator.rb:13:in `<class:Generator>': uninitialized constant Bankai::Generator::DATABASES (NameError)

                                  "(options: #{DATABASES.join('/')})"
  ```

## Solution
- 將 `DATABASES` 改為 `Rails::Generators::Database::DATABASES` 已取得預期的 value。

## Reference
[7.2.0 Rails::Generators::AppBase](https://github.com/rails/rails/blob/v7.2.0/railties/lib/rails/generators/app_base.rb)
[7.1.0 Rails::Generators::AppBase](https://github.com/rails/rails/blob/v7.1.0/railties/lib/rails/generators/app_base.rb)
[7.2.0 Rails::Generators::Database](https://github.com/rails/rails/blob/v7.2.0/railties/lib/rails/generators/database.rb)
[7.1.0 Rails::Generators::Database](https://github.com/rails/rails/blob/v7.1.0/railties/lib/rails/generators/database.rb)
